### PR TITLE
DEVHAS-692: Update GitOps templates for deploying to RHOAI

### DIFF
--- a/templates/http/base/rhoai/dsp-job-rb.yaml
+++ b/templates/http/base/rhoai/dsp-job-rb.yaml
@@ -1,0 +1,12 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ${{ values.name }}-dsp-job-rolebinding
+subjects:
+  - kind: ServiceAccount
+    name: ${{ values.name }}-dsp-job
+    namespace: ${{ values.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ${{ values.name }}-dsp-job-role

--- a/templates/http/base/rhoai/dsp-job-role.yaml
+++ b/templates/http/base/rhoai/dsp-job-role.yaml
@@ -1,0 +1,16 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ${{ values.name }}-dsp-job-role
+  annotations:
+rules:
+  - verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
+    apiGroups:
+      - ""
+    resources:
+      - namespaces

--- a/templates/http/base/rhoai/dsp-job-sa.yaml
+++ b/templates/http/base/rhoai/dsp-job-sa.yaml
@@ -1,0 +1,4 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: ${{ values.name }}-dsp-job

--- a/templates/http/base/rhoai/dsp.yaml
+++ b/templates/http/base/rhoai/dsp.yaml
@@ -1,9 +1,0 @@
-kind: Project
-apiVersion: project.openshift.io/v1
-metadata:
-  name: {{values.dsp}}
-  labels:
-    kubernetes.io/metadata.name: {{values.dsp}}
-    opendatahub.io/dashboard: 'true'
-  annotations:
-    openshift.io/display-name: {{values.dsp}}

--- a/templates/http/base/rhoai/initialize-dsp.yaml
+++ b/templates/http/base/rhoai/initialize-dsp.yaml
@@ -1,0 +1,21 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: initialize-dsp-${{ values.appName }}
+spec:  
+  template:         
+    metadata:
+      name: initialize-dsp-${{ values.appName }}
+    spec:  
+      serviceAccountName: ${{ values.name }}-dsp-job
+      containers:
+      - name: initialize-dsp
+        image: quay.io/redhat-appstudio/appstudio-utils:5bd7d6cb0b17f9f2eab043a8ad16ba3d90551bc2@sha256:8c7fcf86af40c71aeb58e4279625c8308af5144e2f6b8e28b0ec7e795260e5f7
+        command:
+        - /bin/bash
+        - -c
+        - |
+          NS=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+          oc label ns $NS opendatahub.io/dashboard=true
+          
+      restartPolicy: Never

--- a/templates/http/base/rhoai/kustomization.yaml
+++ b/templates/http/base/rhoai/kustomization.yaml
@@ -1,7 +1,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-resources: 
-- dsp.yaml
+commonLabels:         
+  backstage.io/kubernetes-namespace: ${{ values.dsp }} 
+resources:
+- dsp-job-role.yaml
+- dsp-job-rb.yaml
+- dsp-job-sa.yaml
+- initialize-dsp.yaml
 - notebook.yaml
 - serviceaccount.yaml
 - pvc.yaml

--- a/templates/http/base/rhoai/notebook.yaml
+++ b/templates/http/base/rhoai/notebook.yaml
@@ -4,10 +4,11 @@ metadata:
   annotations:
     notebooks.opendatahub.io/inject-oauth: 'true'
     opendatahub.io/image-display-name: Minimal Python
-    openshift.io/display-name: {{values.name}}
-  name: {{values.name}}
-  namespace: {{values.dsp}}
+    openshift.io/display-name: ${{ values.name }}
+  name: ${{ values.name }}
+  namespace: ${{ values.namespace }}
   labels:
+    app: ${{ values.name }}
     opendatahub.io/dashboard: 'true'
     opendatahub.io/odh-managed: 'true'
 spec:
@@ -24,18 +25,18 @@ spec:
           readinessProbe:
             failureThreshold: 3
             httpGet:
-              path: /notebook/{{values.dsp}}/{{values.name}}/api
+              path: /notebook/${{ values.namespace }}/${{ values.name }}/api
               port: notebook-port
               scheme: HTTP
             initialDelaySeconds: 10
             periodSeconds: 5
             successThreshold: 1
             timeoutSeconds: 1
-          name: {{values.name}}
+          name: ${{ values.name }}
           livenessProbe:
             failureThreshold: 3
             httpGet:
-              path: /notebook/{{values.dsp}}/{{values.name}}/api
+              path: /notebook/${{ values.namespace }}/${{ values.name }}/api
               port: notebook-port
               scheme: HTTP
             initialDelaySeconds: 10
@@ -44,13 +45,17 @@ spec:
             timeoutSeconds: 1
           env:
             - name: NOTEBOOK_ARGS
+              value: |-
+                --ServerApp.port=8888
+                --ServerApp.base_url=/notebook/${{ values.namespace }}/${{ values.name }}
+                --ServerApp.quit_button=False
             - name: JUPYTER_IMAGE
               value: 'image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/s2i-minimal-notebook:2024.1'
             - name: MODEL_ENDPOINT
-              value: http://{{values.name}}-model-server.{{values.namespace}}.svc.cluster.local:{{values.modelServicePort}}
+              value: http://${{ values.name }}-model-server.${{ values.namespace }}.svc.cluster.local:${{ values.modelServicePort }}
             {%- if values.vllmSelected %}
             - name: MODEL_NAME
-              value: "{{values.vllmModelName}}"
+              value: "${{ values.vllmModelName }}"
             {%- endif %}
           ports:
             - containerPort: 8888
@@ -59,7 +64,7 @@ spec:
           imagePullPolicy: Always
           volumeMounts:
             - mountPath: /opt/app-root/src
-              name: {{values.name}}
+              name: ${{ values.name }}-rhoai
             - mountPath: /dev/shm
               name: shm
           image: 'image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/s2i-minimal-notebook:2024.1'
@@ -102,13 +107,26 @@ spec:
               name: oauth-proxy
               protocol: TCP
           imagePullPolicy: Always
+          volumeMounts:
+            - mountPath: /etc/oauth/config
+              name: oauth-config
+            - mountPath: /etc/tls/private
+              name: tls-certificates
           image: 'registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4bef31eb993feb6f1096b51b4876c65a6fb1f4401fee97fa4f4542b6b7c9bc46'
       enableServiceLinks: false
-      serviceAccountName: {{values.name}}
+      serviceAccountName: ${{ values.name }}
       volumes:
-        - name: {{values.name}}
+        - name: ${{ values.name }}-rhoai
           persistentVolumeClaim:
-            claimName: {{values.name}}
+            claimName: ${{ values.name }}-rhoai
         - emptyDir:
             medium: Memory
           name: shm
+        - name: oauth-config
+          secret:
+            defaultMode: 420
+            secretName: ${{ values.name }}-oauth-config
+        - name: tls-certificates
+          secret:
+            defaultMode: 420
+            secretName: ${{ values.name }}-tls

--- a/templates/http/base/rhoai/pvc.yaml
+++ b/templates/http/base/rhoai/pvc.yaml
@@ -2,9 +2,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   annotations:
-    openshift.io/display-name: {{values.name}}
-  name: {{values.name}}
-  namespace: {{values.dsp}}
+    openshift.io/display-name: ${{ values.name }}
+  name: ${{ values.name }}-rhoai
   labels:
     opendatahub.io/dashboard: 'true'
 spec:

--- a/templates/http/base/rhoai/serviceaccount.yaml
+++ b/templates/http/base/rhoai/serviceaccount.yaml
@@ -1,7 +1,6 @@
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: {{values.name}}
-  namespace: {{values.dsp}}
+  name: ${{ values.name }}
   labels:
-    notebook-name: {{values.name}}
+    notebook-name: ${{ values.name }}


### PR DESCRIPTION
Updates the GitOps template resources to properly support deploying RHOAI workbenches through ArgoCD:
- Fixes to the Notebook CR to ensure the probes hit the right endpoint
- Job to label the namespace the Notebook is deployed as a Data Science Project in RHOAI
- Role, Rolebinding, and Service Account to allow the job to execute successfully

