### PR TITLE
[DEVHAS-701] Create a Job to clone source repository in RHOAI workbench

### DIFF
--- a/templates/http/base/rhoai/dsp-clone-job.yaml
+++ b/templates/http/base/rhoai/dsp-clone-job.yaml
@@ -1,0 +1,21 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: dsp-clone-job-{{values.appName}}
+spec:  
+  template:         
+    metadata:
+      name: initialize-dsp-{{values.appName}}
+    spec:  
+      serviceAccountName: {{values.name}}-dsp-job
+      containers:
+      - name: initialize-dsp
+        image: quay.io/redhat-appstudio/appstudio-utils:5bd7d6cb0b17f9f2eab043a8ad16ba3d90551bc2@sha256:8c7fcf86af40c71aeb58e4279625c8308af5144e2f6b8e28b0ec7e795260e5f7
+        command:
+        - /bin/bash
+        - -c
+        - |
+          NS=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+          oc wait -l statefulset={{values.name}} --for=condition=ready pod --timeout=300s
+          oc exec  StatefulSet/{{values.name}} -- git clone {{values.srcRepoURL}}
+      restartPolicy: Never

--- a/templates/http/base/rhoai/dsp-clone-job.yaml
+++ b/templates/http/base/rhoai/dsp-clone-job.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:  
   template:         
     metadata:
-      name: initialize-dsp-{{values.appName}}
+      name: dsp-clone-job-{{values.appName}}
     spec:  
       serviceAccountName: {{values.name}}-dsp-job
       containers:

--- a/templates/http/base/rhoai/dsp-job-role.yaml
+++ b/templates/http/base/rhoai/dsp-job-role.yaml
@@ -14,3 +14,18 @@ rules:
       - ""
     resources:
       - namespaces
+  # The following roles are needed to ensure the dsp clone job can execute commands in the RHOAI workbench
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - "apps/v1"
+    resources:
+      - statefulsets
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["get", "create"]

--- a/templates/http/base/rhoai/kustomization.yaml
+++ b/templates/http/base/rhoai/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
 - dsp-job-role.yaml
 - dsp-job-rb.yaml
 - dsp-job-sa.yaml
+- dsp-clone-job.yaml
 - initialize-dsp.yaml
 - notebook.yaml
 - serviceaccount.yaml


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/DEVHAS-701

- Adds a Kubernetes job that will wait for the RHOAI workbench to start, execs into the workbench and git clones the source repository
- Updates the DSP Job SA account roles to include permissions to exec into pods.