### PR TITLE
Add back env vars for model service

### DIFF
--- a/templates/http/base/rhoai/initialize-dsp.yaml
+++ b/templates/http/base/rhoai/initialize-dsp.yaml
@@ -94,6 +94,12 @@ spec:
                                             --ServerApp.quit_button=False
                       - name: JUPYTER_IMAGE
                         value: 'image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/s2i-minimal-notebook:2024.1'
+                      - name: MODEL_ENDPOINT
+                        value: http://{{values.name}}-model-server.{{values.namespace}}.svc.cluster.local:{{values.modelServicePort}}
+                      {%- if values.vllmSelected %}
+                      - name: MODEL_NAME
+                        value: "{{values.vllmModelName}}"
+                      {%- endif %}
                     ports:
                       - containerPort: 8888
                         name: notebook-port


### PR DESCRIPTION
Forgot to port back the model env vars when updating the Notebook 🤦 