### PR TITLE
[DEVHAS-733] Store model server environment variables in ConfigMap

### DIFF
--- a/templates/http/base/deployment.yaml
+++ b/templates/http/base/deployment.yaml
@@ -23,15 +23,11 @@ spec:
         app.kubernetes.io/instance:  {{values.name}}
     spec:
       containers:
-      - env:
-        - name: MODEL_ENDPOINT
-          value: http://{{values.name}}-model-server:{{values.modelServicePort}}
-        {%- if values.vllmSelected %}
-        - name: MODEL_NAME
-          value: "{{values.vllmModelName}}"
-        {%- endif %}
-        image:  {{values.appContainer}}
+      - image:  {{values.appContainer}}
         name: app-inference
+        envFrom:
+        - configMapRef:
+            name: {{values.name}}-model-config
         ports:
         - containerPort: {{values.appPort}}
         securityContext:

--- a/templates/http/base/kustomization.yaml
+++ b/templates/http/base/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
 - deployment.yaml
 - route.yaml
 - service.yaml
+- model-config.yaml
 {%- if values.rhoaiSelected %}
 - rhoai/
 {%- endif %}

--- a/templates/http/base/model-config.yaml
+++ b/templates/http/base/model-config.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{values.name}}-model-config
+data:
+  MODEL_ENDPOINT: "http://{{values.name}}-model-server:{{values.modelServicePort}}"
+  {%- if values.vllmSelected %}
+  MODEL_NAME: "{{values.vllmModelName}}"
+  {%- endif %}

--- a/templates/http/base/rhoai/initialize-dsp.yaml
+++ b/templates/http/base/rhoai/initialize-dsp.yaml
@@ -94,12 +94,9 @@ spec:
                                             --ServerApp.quit_button=False
                       - name: JUPYTER_IMAGE
                         value: 'image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/s2i-minimal-notebook:2024.1'
-                      - name: MODEL_ENDPOINT
-                        value: http://{{values.name}}-model-server.{{values.namespace}}.svc.cluster.local:{{values.modelServicePort}}
-                      {%- if values.vllmSelected %}
-                      - name: MODEL_NAME
-                        value: "{{values.vllmModelName}}"
-                      {%- endif %}
+                    envFrom:
+                    - configMapRef:
+                        name: {{values.name}}-model-config
                     ports:
                       - containerPort: 8888
                         name: notebook-port


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/DEVHAS-733

Modifies how we store environment variables relating to the model service, so that they're stored in a ConfigMap instead, allowing them to be centrally defined. Defining them in a ConfigMap now allows RHOAI to display the environment variables in workbench settings view:
<img width="656" alt="Screenshot 2024-07-23 at 5 53 07 PM" src="https://github.com/user-attachments/assets/d9238aad-2eed-454a-aaa2-baee267e90b0">

