### PR TITLE
update command args to be able to accept value

### DIFF
--- a/templates/http/base/deployment-model-server.yaml
+++ b/templates/http/base/deployment-model-server.yaml
@@ -26,7 +26,7 @@ spec:
       initContainers:
       - name: model-file
         image: {{values.initContainer}}
-        command: {{values.command}}
+        command: {{values.modelInitCommand}}
         volumeMounts:
         - name: model-file
           mountPath: /shared

--- a/templates/http/base/deployment-model-server.yaml
+++ b/templates/http/base/deployment-model-server.yaml
@@ -58,7 +58,7 @@ spec:
         - name: PORT
           value: "{{values.modelServicePort}}"
         - name: MODEL_PATH
-          value: /model/model.file
+          value: {{values.modelPath}}
         - name: CHAT_FORMAT
           value: openchat
         image: {{values.modelServiceContainer}}

--- a/templates/http/base/deployment-model-server.yaml
+++ b/templates/http/base/deployment-model-server.yaml
@@ -26,7 +26,7 @@ spec:
       initContainers:
       - name: model-file
         image: {{values.initContainer}}
-        command: ['/usr/bin/install', "/model/model.file", "/shared/"]
+        command: {{values.command}}
         volumeMounts:
         - name: model-file
           mountPath: /shared


### PR DESCRIPTION
update command args to be able to pass in via `values`

the original hard-coded one `['/usr/bin/install', "/model/model.file", "/shared/"]` is only for a single model file. However, for some models, it will require to copy over the entire directory instead of a single file. 

the `facebook/detr-resnet-101` model which is being used for object detection is one of the models requires the entire folder to run the model. 