### PR TITLE
DEVHAS-731: Update templates to allow model host and name to be passed in

### DIFF
--- a/templates/http/base/kustomization.yaml
+++ b/templates/http/base/kustomization.yaml
@@ -8,11 +8,13 @@ commonLabels:
   app.kubernetes.io/part-of: {{values.name}}
 resources: 
 - initialize-namespace.yaml
-{%- if values.vllmSelected %}
+{%- if values.vllmSelected and not values.existingModelServer %}
 - pvc.yaml
 {%- endif %}
+{%- if not values.existingModelServer %}
 - deployment-model-server.yaml
 - service-model-server.yaml
+{%- endif %}
 - deployment.yaml
 - route.yaml
 - service.yaml

--- a/templates/http/base/kustomization.yaml
+++ b/templates/http/base/kustomization.yaml
@@ -8,7 +8,7 @@ commonLabels:
   app.kubernetes.io/part-of: {{values.name}}
 resources: 
 - initialize-namespace.yaml
-{%- if values.vllmSelected and not values.existingModelServer %}
+{%- if values.vllmSelected %}
 - pvc.yaml
 {%- endif %}
 {%- if not values.existingModelServer %}

--- a/templates/http/base/model-config.yaml
+++ b/templates/http/base/model-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{values.name}}-model-config
 data:
   {%- if values.existingModelServer %}
-  MODEL_ENDPOINT: "{{values.modelServerHost}}"
+  MODEL_ENDPOINT: "{{values.modelEndpoint}}"
   {%- else %}
   MODEL_ENDPOINT: "http://{{values.name}}-model-server:{{values.modelServicePort}}"
   {%- endif %}

--- a/templates/http/base/model-config.yaml
+++ b/templates/http/base/model-config.yaml
@@ -3,7 +3,11 @@ kind: ConfigMap
 metadata:
   name: {{values.name}}-model-config
 data:
+  {%- if values.existingModelServer %}
+  MODEL_ENDPOINT: "{{values.modelServerHost}}"
+  {%- else %}
   MODEL_ENDPOINT: "http://{{values.name}}-model-server:{{values.modelServicePort}}"
-  {%- if values.vllmSelected %}
-  MODEL_NAME: "{{values.vllmModelName}}"
+  {%- endif %}
+  {%- if values.vllmSelected or values.existingModelServer %}
+  MODEL_NAME: "{{values.modelName}}"
   {%- endif %}


### PR DESCRIPTION
- Allows model server endpoint and model name to be passed in to the model server configmap.
    - When the `values.existingModelServer` value is set to true, the `MODEL_ENDPOINT` value is set to `values.modelServerHost`, and `MODEL_NAME` is set to `values.modelName`
- Changes the corresponding `MODEL_NAME` template value from `values.vllmModelName` to `values.modelName` to keep it more generic
    - Will need update in the software template in order to pull these changes in
- When `values.existingModelServer` is set to true, the model deployment and server are not deployed