### PR TITLE
vllmModelName -> modelName

### DIFF
--- a/templates/http/base/deployment-model-server.yaml
+++ b/templates/http/base/deployment-model-server.yaml
@@ -36,7 +36,7 @@ spec:
       - image: {{values.vllmModelServiceContainer}}
         args: [
             "--model",
-            "{{values.vllmModelName}}",
+            "{{values.modelName}}",
             "--port",
             "{{values.modelServicePort}}",
             "--download-dir",


### PR DESCRIPTION
Looks like the model deployment also referenced `vllmModelName`. I didn't see any other results turn up for `vllmModelName`, so this should be sufficient.