### PR TITLE
Add MODEL_ENDPOINT_BEARER to deployment

### DIFF
--- a/templates/http/base/deployment.yaml
+++ b/templates/http/base/deployment.yaml
@@ -34,7 +34,7 @@ spec:
         {%- endif %}
         {%- if values.includeModelEndpointSecret %}
         env:
-        - name: MODEL_ENDPOINT_API_KEY
+        - name: MODEL_ENDPOINT_BEARER
           valueFrom:
             secretKeyRef:
               name: {{ values.modelEndpointSecretName }}

--- a/templates/http/base/deployment.yaml
+++ b/templates/http/base/deployment.yaml
@@ -32,6 +32,14 @@ spec:
         - configMapRef:
             name: {{values.name}}-database-config
         {%- endif %}
+        {%- if values.includeModelEndpointSecret %}
+        env:
+        - name: MODEL_ENDPOINT_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ values.modelEndpointSecretName }}
+              key: {{ values.modelEndpointSecretKey }}
+        {%- endif %}
         ports:
         - containerPort: {{values.appPort}}
         securityContext:

--- a/templates/http/base/rhoai/initialize-dsp.yaml
+++ b/templates/http/base/rhoai/initialize-dsp.yaml
@@ -90,6 +90,13 @@ spec:
                       successThreshold: 1
                       timeoutSeconds: 1
                     env:
+                      {%- if values.includeModelEndpointSecret %}
+                      - name: MODEL_ENDPOINT_BEARER
+                        valueFrom:
+                          secretKeyRef:
+                            name: ${{  values.modelEndpointSecretName  }}
+                            key: ${{  values.modelEndpointSecretKey  }}
+                      {%- endif %}
                       - name: NOTEBOOK_ARGS
                         value: |-
                           --ServerApp.port=8888


### PR DESCRIPTION
### What does this PR do?:
Adds an extra env var taken from a given secret. The env var is an optional API_KEY which (when provided) is used for bearer authentication process during requests to the given model server.

Draft: as it's currently blocked by https://github.com/containers/ai-lab-recipes/pull/790 needs to be merged first and all updates is necessary to be pulled inside the github.com/redhat-ai-dev/ai-lab-samples.  

**UPDATE**: After I've test all non-RHOAI deployments that work fine, I'll apply the same to RHOAI.

### Which issue(s) this PR fixes:
https://issues.redhat.com/browse/DEVAI-158

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [ ] Tested and Verified

  <!-- _I have verified that the changes were tested manually_ -->

- [ ] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->


### How to test changes / Special notes to the reviewer:
I'll add specific test examples in here and I'll soon open a similar pr on the templates side (updating the template skeleton) with detailed instructions for testing.
