### PR TITLE
Remove RHTAP Reference From Tekton Task

### DIFF
--- a/templates/http/base/initialize-namespace.yaml
+++ b/templates/http/base/initialize-namespace.yaml
@@ -16,7 +16,7 @@ spec:
         - -c
         - |
           NS=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace) 
-          echo "Initialize RHTAP Namespace: $NS"  
+          echo "Initialize RHDH Namespace: $NS"  
           cat <<CONFIGURE_PIPELINE | oc create -f - 
           apiVersion: tekton.dev/v1
           kind: PipelineRun
@@ -35,7 +35,7 @@ spec:
                       - name: name
                         value: dev-namespace-setup
                       - name: namespace
-                        value: {{values.rhtapNamespace}}
+                        value: {{values.rhdhNamespace}}
                     resolver: cluster 
           CONFIGURE_PIPELINE
           


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->

This PR removes RHTAP references from the Tekton Task used to configure custom namespaces. It is related to comments made in this PR: https://github.com/redhat-ai-dev/ai-lab-template/pull/41#discussion_r1804951723


### Which issue(s) this PR fixes:
<!-- _Link to Github/JIRA issue(s)_ -->

https://issues.redhat.com/browse/DEVAI-134

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [ ] Tested and Verified

  <!-- _I have verified that the changes were tested manually_ -->

- [ ] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->


### How to test changes / Special notes to the reviewer:
