### PR TITLE
Update README To Separate From Templating

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ These definitons are currently being used in:
 
 ## Contributing
 
-When making a change to [./templates/app-of-apps](./templates/app-of-apps/) or [./templates/http](./templates/http/), please ensure that any changes affecting how these definitions work are accompanied by updates to the dcoumentation in the repositories listed under [Dependent Repositories](#dependent-repositories).
+When making a change to [./templates/app-of-apps](./templates/app-of-apps/) or [./templates/http](./templates/http/), please ensure that any changes affecting how these definitions work are accompanied by updates to the documentation in the repositories listed under [Dependent Repositories](#dependent-repositories).

--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ These definitons are currently being used in:
 
 ## Contributing
 
-When making a change to [./templates/app-of-apps](./templates/app-of-apps/) or [./templates/http](./templates/http/), please ensure that any necessary changes to documentation are also made to repositories listed under [Dependent Repositories](#dependent-repositories).
+When making a change to [./templates/app-of-apps](./templates/app-of-apps/) or [./templates/http](./templates/http/), please ensure that any changes affecting how these definitions work are accompanied by updates to the dcoumentation in the repositories listed under [Dependent Repositories](#dependent-repositories).

--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
-# ai-lab-template-gitops
+# GitOps For Software Templates
 
-# Gitops Repo Patterns
+This repository contains HTTP GitOps components for use with AI Software Templates. 
 
-This repository contains an HTTP Gitops repository format component for use as the AI-Lab Gitops template.
+## Dependent Repositories
 
-## HTTP
+These definitons are currently being used in:
 
-This contains a deployment with the following characteristics:
+- [https://github.com/redhat-ai-dev/ai-lab-template](https://github.com/redhat-ai-dev/ai-lab-template)
+- [https://github.com/redhat-ai-dev/ai-lab-template-experiment](https://github.com/redhat-ai-dev/ai-lab-template-experiment)
 
-**Model service image** `{{values.modelServiceContainer}}` **listening on port** `{{values.modelServicePort}}`.
+## Contributing
 
-**App interface image** `{{values.appContainer}}` **listening on port** `{{values.appPort}}` for service and routing.
-
-This matches the current AI-Lab software template default deployment.
+When making a change to [./templates/app-of-apps](./templates/app-of-apps/) or [./templates/http](./templates/http/), please ensure that any necessary changes to documentation are also made to repositories listed under [Dependent Repositories](#dependent-repositories).


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->

This PR removes the templated README that is imported by the software templates repo in favour of a more repository centric document. The template repos are going to store their own copy of Tech Docs related to the GitOps definitions defined in this ai-lab-app repo moving forward.

### Which issue(s) this PR fixes:
<!-- _Link to Github/JIRA issue(s)_ -->

N/A

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [ ] Tested and Verified

  <!-- _I have verified that the changes were tested manually_ -->

- [x] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->


### How to test changes / Special notes to the reviewer:
